### PR TITLE
chore(build): add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM quay.io/deis/go-dev:v1.17.2 as go-build
+
+WORKDIR /go/src/github.com/deis/object-storage-cli
+COPY . ./
+RUN make bootstrap DEV_ENV_CMD=
+RUN make build-all DEV_ENV_CMD= DIST_DIR=/opt
+
+FROM scratch
+COPY --from=go-build /opt /


### PR DESCRIPTION
so that this can be built on quay.io or similar, and projects depending on it can just "COPY --from=..." it from that image

https://quay.io/repository/pngmbh/object-storage-cli

This is a bit hacky, but IMHO less so than downloading it from some sort of S3-bucket somewhere.